### PR TITLE
Fix issue with quitting the server

### DIFF
--- a/src/main/java/io/github/kurrycat/mpkmod/compatability/API.java
+++ b/src/main/java/io/github/kurrycat/mpkmod/compatability/API.java
@@ -41,6 +41,7 @@ public class API {
     public static MainGuiScreen mainGUI;
     public static Map<String, MPKGuiScreen> guiScreenMap = new HashMap<>();
     public static Map<String, Procedure> keyBindingMap = new HashMap<>();
+    public static boolean discordRpcInitialized = false;
     private static FunctionHolder functionHolder;
 
     /**
@@ -82,9 +83,11 @@ public class API {
         API.LOGGER.info(API.DISCORD_RPC_MARKER, "Starting DiscordRPC...");
         try {
             DiscordRPC.init();
+            discordRpcInitialized = true;
         } catch (Exception e) {
             API.LOGGER.error(API.DISCORD_RPC_MARKER, "Unexpected exception while initializing DiscordRPC:");
             e.printStackTrace();
+            discordRpcInitialized = false;
         }
 
         EventAPI.addListener(
@@ -222,12 +225,12 @@ public class API {
 
         public static void onServerConnect(boolean isLocal) {
             Minecraft.updateWorldState(Event.EventType.SERVER_CONNECT, isLocal);
-            DiscordRPC.updateWorldAndPlayState();
+            if (discordRpcInitialized) DiscordRPC.updateWorldAndPlayState();
         }
 
         public static void onServerDisconnect() {
             Minecraft.updateWorldState(Event.EventType.SERVER_DISCONNECT, false);
-            DiscordRPC.updateWorldAndPlayState();
+            if (discordRpcInitialized) DiscordRPC.updateWorldAndPlayState();
         }
 
         public static void onKeyInput(int keyCode, String key, boolean pressed) {

--- a/src/main/java/io/github/kurrycat/mpkmod/discord/DiscordRPC.java
+++ b/src/main/java/io/github/kurrycat/mpkmod/discord/DiscordRPC.java
@@ -50,7 +50,7 @@ public class DiscordRPC {
             activity.timestamps().setStart(API.gameStartedInstant);
 
             activity.assets().setLargeImage("mpkmod_logo");
-            if (core != null)
+            if (core != null && core.isOpen())
                 core.activityManager().updateActivity(activity);
         }
     }


### PR DESCRIPTION
There is an issue with the newest version, where if DiscordRPC fails to initialize, and the player quits a server, they will not actually Disconnect. In most cases you won't be able to rejoin the server, as you are already "On the Server". Some other funky stuff goes on, like still being able to receive chat messages from that server, the daytime flickering between the current and last server and you being able to see the hotbar-messages and tab list.

This pull requests attempts to fix this issue, however for me it doesn't show up on discord at all now.