### PR TITLE
Options rework + crash fix

### DIFF
--- a/src/main/java/io/github/kurrycat/mpkmod/gui/screens/options_gui/Option.java
+++ b/src/main/java/io/github/kurrycat/mpkmod/gui/screens/options_gui/Option.java
@@ -79,7 +79,7 @@ public class Option {
             Option option = new Option(name, value, value, type).setCategory(category).link(f);
             optionMap.put(name, option);
 
-            API.LOGGER.info("Option added to map: {} with default value: {}", name, value);
+            API.LOGGER.info("Option of type {} added to map: {} with default value: {}", type, name, value);
         }
 
         List<Tuple<ChangeListener, Method>> listeners = ClassUtil.getMethodAnnotations(classes, ChangeListener.class);
@@ -163,6 +163,10 @@ public class Option {
         switch (this.type) {
             case BOOLEAN:
                 return getBoolean();
+            case INTEGER:
+                return getInteger();
+            case DOUBLE:
+                return getDouble();
             default:
                 return getValue();
         }
@@ -178,6 +182,18 @@ public class Option {
         if (ValueType.BOOLEAN.equals(this.type))
             this.setValue(value.toString());
         return this;
+    }
+
+    public Integer getInteger() {
+        if(this.type == ValueType.INTEGER)
+            return Integer.parseInt(this.value);
+        return 0;
+    }
+
+    public Double getDouble() {
+        if(this.type == ValueType.DOUBLE)
+            return Double.parseDouble(this.value);
+        return 0.0;
     }
 
     public String getCategory() {
@@ -239,6 +255,9 @@ public class Option {
         COLOR;
     }
 
+    /**
+     * Marks a field as an MPK-Option. The field has to be public.
+     */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.FIELD)
     public @interface Field {

--- a/src/main/java/io/github/kurrycat/mpkmod/gui/screens/options_gui/OptionListItem.java
+++ b/src/main/java/io/github/kurrycat/mpkmod/gui/screens/options_gui/OptionListItem.java
@@ -1,0 +1,86 @@
+package io.github.kurrycat.mpkmod.gui.screens.options_gui;
+
+import io.github.kurrycat.mpkmod.compatability.MCClasses.FontRenderer;
+import io.github.kurrycat.mpkmod.compatability.MCClasses.Renderer2D;
+import io.github.kurrycat.mpkmod.gui.components.*;
+import io.github.kurrycat.mpkmod.gui.components.Button;
+import io.github.kurrycat.mpkmod.gui.components.Component;
+import io.github.kurrycat.mpkmod.util.ArrayListUtil;
+import io.github.kurrycat.mpkmod.util.Mouse;
+import io.github.kurrycat.mpkmod.util.Vector2D;
+
+import java.awt.*;
+import java.util.ArrayList;
+
+public abstract class OptionListItem extends ScrollableListItem<OptionListItem> {
+
+    private static final Color optionListColorItemEdge = new Color(255, 255, 255, 95);
+    private static final Color optionListColorBg = new Color(31, 31, 31, 150);
+    private final Button resetButton;
+    protected final ArrayList<Component> updateComponents = new ArrayList<>();
+    public Option option;
+    protected String value;
+    protected Option.ValueType type;
+
+    public OptionListItem(ScrollableList<OptionListItem> parent, Option option) {
+        super(parent);
+        this.option = option;
+        this.value = option.getValue();
+        this.type = option.getType();
+
+        resetButton = new Button("Reset", Vector2D.OFFSCREEN, new Vector2D(30, 11), mouseButton -> {
+            if (mouseButton == Mouse.Button.LEFT) {
+                loadDefaultValue();
+            }
+        });
+        updateComponents.add(resetButton);
+    }
+
+    public void loadDefaultValue() {
+        value = option.getDefaultValue();
+        updateDisplayValue();
+    }
+    protected abstract void updateDisplayValue();
+
+    public void update() {
+        option.setValue(value);
+    }
+
+    @Override
+    public void render(int index, Vector2D pos, Vector2D size, Vector2D mouse) {
+        Renderer2D.drawRectWithEdge(pos, size, 1, optionListColorBg, optionListColorItemEdge);
+
+        FontRenderer.drawLeftCenteredString(
+                option.getName(),
+                pos.add(5, size.getY() / 2),
+                Color.WHITE,
+                false
+        );
+
+        renderTypeSpecific(index, pos, size, mouse);
+
+        resetButton.enabled = !option.getDefaultValue().equals(value);
+        resetButton.pos = pos.add(size.getX() - 35, size.getY() / 2 - 5);
+        resetButton.render(mouse);
+    }
+
+    protected abstract void renderTypeSpecific(int index, Vector2D pos, Vector2D size, Vector2D mouse);
+
+    public boolean handleMouseInput(Mouse.State state, Vector2D mousePos, Mouse.Button button) {
+        return ArrayListUtil.orMapAll(
+                ArrayListUtil.getAllOfType(MouseInputListener.class, updateComponents),
+                ele -> ele.handleMouseInput(state, mousePos, button)
+        );
+    }
+
+    public boolean handleKeyInput(char keyCode, String key, boolean pressed) {
+        return ArrayListUtil.orMapAll(
+                ArrayListUtil.getAllOfType(KeyInputListener.class, updateComponents),
+                ele -> ele.handleKeyInput(keyCode, key, pressed)
+        );
+    }
+
+    public int getHeight() {
+        return 21;
+    }
+}

--- a/src/main/java/io/github/kurrycat/mpkmod/gui/screens/options_gui/OptionListItemBoolean.java
+++ b/src/main/java/io/github/kurrycat/mpkmod/gui/screens/options_gui/OptionListItemBoolean.java
@@ -1,0 +1,31 @@
+package io.github.kurrycat.mpkmod.gui.screens.options_gui;
+
+import io.github.kurrycat.mpkmod.gui.components.CheckButton;
+import io.github.kurrycat.mpkmod.gui.components.ScrollableList;
+import io.github.kurrycat.mpkmod.util.Vector2D;
+
+public class OptionListItemBoolean extends OptionListItem {
+    private final CheckButton checkButton;
+
+    public OptionListItemBoolean(ScrollableList<OptionListItem> parent, Option option) {
+        super(parent, option);
+
+        checkButton = new CheckButton(Vector2D.OFFSCREEN, checked -> value = String.valueOf(checked));
+        checkButton.enabled = option.getType() == Option.ValueType.BOOLEAN;
+        if (checkButton.enabled) {
+            checkButton.setChecked(option.getBoolean());
+            updateComponents.add(checkButton);
+        }
+    }
+
+    protected void updateDisplayValue() {
+        if (checkButton.enabled) {
+            checkButton.setChecked(Boolean.parseBoolean(value));
+        }
+    }
+
+    protected void renderTypeSpecific(int index, Vector2D pos, Vector2D size, Vector2D mouse) {
+        checkButton.pos = pos.add(size.getX() - 40 - checkButton.getDisplayedSize().getX(), size.getY() / 2 - 5);
+        checkButton.render(mouse);
+    }
+}

--- a/src/main/java/io/github/kurrycat/mpkmod/gui/screens/options_gui/OptionListItemDefault.java
+++ b/src/main/java/io/github/kurrycat/mpkmod/gui/screens/options_gui/OptionListItemDefault.java
@@ -1,0 +1,25 @@
+package io.github.kurrycat.mpkmod.gui.screens.options_gui;
+
+import io.github.kurrycat.mpkmod.compatability.MCClasses.FontRenderer;
+import io.github.kurrycat.mpkmod.gui.components.ScrollableList;
+import io.github.kurrycat.mpkmod.util.Vector2D;
+
+import java.awt.*;
+
+public class OptionListItemDefault extends OptionListItem {
+    public OptionListItemDefault(ScrollableList<OptionListItem> parent, Option option) {
+        super(parent, option);
+    }
+
+    protected void updateDisplayValue() {
+    }
+
+    protected void renderTypeSpecific(int index, Vector2D pos, Vector2D size, Vector2D mouse) {
+        FontRenderer.drawRightCenteredString(
+                value,
+                pos.add(size.getX() - 40, size.getY() / 2),
+                Color.WHITE,
+                false
+        );
+    }
+}

--- a/src/main/java/io/github/kurrycat/mpkmod/gui/screens/options_gui/OptionListItemInteger.java
+++ b/src/main/java/io/github/kurrycat/mpkmod/gui/screens/options_gui/OptionListItemInteger.java
@@ -1,0 +1,29 @@
+package io.github.kurrycat.mpkmod.gui.screens.options_gui;
+
+import io.github.kurrycat.mpkmod.gui.components.InputField;
+import io.github.kurrycat.mpkmod.gui.components.ScrollableList;
+import io.github.kurrycat.mpkmod.util.Vector2D;
+
+public class OptionListItemInteger extends OptionListItem {
+    private final InputField inputField;
+
+    public OptionListItemInteger(ScrollableList<OptionListItem> parent, Option option) {
+        super(parent, option);
+
+        inputField = new InputField(option.getValue(), Vector2D.OFFSCREEN, 64, true);
+        inputField.setOnContentChange(content -> {
+            this.value = content.getContent();
+        });
+
+        updateComponents.add(inputField);
+    }
+
+    protected void updateDisplayValue() {
+        inputField.content = this.value;
+    }
+
+    protected void renderTypeSpecific(int index, Vector2D pos, Vector2D size, Vector2D mouse) {
+        inputField.pos = pos.add(size.getX() - 40 - inputField.getDisplayedSize().getX(), size.getY() / 2 - 5);
+        inputField.render(mouse);
+    }
+}

--- a/src/main/java/io/github/kurrycat/mpkmod/gui/screens/options_gui/OptionListItemString.java
+++ b/src/main/java/io/github/kurrycat/mpkmod/gui/screens/options_gui/OptionListItemString.java
@@ -1,0 +1,29 @@
+package io.github.kurrycat.mpkmod.gui.screens.options_gui;
+
+import io.github.kurrycat.mpkmod.gui.components.InputField;
+import io.github.kurrycat.mpkmod.gui.components.ScrollableList;
+import io.github.kurrycat.mpkmod.util.Vector2D;
+
+public class OptionListItemString extends OptionListItem {
+    private final InputField inputField;
+
+    public OptionListItemString(ScrollableList<OptionListItem> parent, Option option) {
+        super(parent, option);
+
+        inputField = new InputField(option.getValue(), Vector2D.OFFSCREEN, 256);
+        inputField.setOnContentChange(content -> {
+            this.value = content.getContent();
+        });
+
+        updateComponents.add(inputField);
+    }
+
+    protected void updateDisplayValue() {
+        inputField.content = this.value;
+    }
+
+    protected void renderTypeSpecific(int index, Vector2D pos, Vector2D size, Vector2D mouse) {
+        inputField.pos = pos.add(size.getX() - 40 - inputField.getDisplayedSize().getX(), size.getY() / 2 - 5);
+        inputField.render(mouse);
+    }
+}

--- a/src/main/java/io/github/kurrycat/mpkmod/util/ClassUtil.java
+++ b/src/main/java/io/github/kurrycat/mpkmod/util/ClassUtil.java
@@ -44,7 +44,7 @@ public class ClassUtil {
         final String pkgPath = pkgName.replace('.', '/');
         URI pkg;
         try {
-            pkg = Objects.requireNonNull(ClassLoader.getSystemClassLoader().getResource(pkgPath)).toURI();
+            pkg = Objects.requireNonNull(ClassUtil.class.getClassLoader().getResource(pkgPath)).toURI();
         } catch (URISyntaxException ignored) {
             return null;
         }

--- a/src/main/resources/assets/mpkmod/lang/en_US.lang
+++ b/src/main/resources/assets/mpkmod/lang/en_US.lang
@@ -1,2 +1,6 @@
 mpkmod.key.main_gui.desc=Open MPK Mod GUI
 mpkmod.key.lb_gui.desc=Open Landing Block GUI
+mpkmod.key.lb_set.desc=Set Landing Block
+mpkmod.key.options_gui.desc=Open Options GUI
+mpkmod.main_gui.title=MPK Mod GUI
+mpkmod.lb_gui.title=Landing Block GUI

--- a/src/main/resources/assets/mpkmod/lang/en_us.json
+++ b/src/main/resources/assets/mpkmod/lang/en_us.json
@@ -1,6 +1,0 @@
-{
-  "mpkmod.main_gui.title": "MPK Mod GUI",
-  "mpkmod.key.main_gui.desc": "Open MPK Mod GUI",
-  "mpkmod.lb_gui.title": "Landing Block GUI",
-  "mpkmod.key.lb_gui.desc": "Open Landing Block GUI"
-}

--- a/src/main/resources/assets/mpkmod/lang/pl_pl.json
+++ b/src/main/resources/assets/mpkmod/lang/pl_pl.json
@@ -1,6 +1,0 @@
-{
-  "mpkmod.main_gui.title": "Menu Moda MPK",
-  "mpkmod.key.main_gui.desc": "Otwórz menu Moda MPK",
-  "mpkmod.lb_gui.title": "Menu bloku lądowania",
-  "mpkmod.key.lb_gui.desc": "Otwórz menu bloku lądowania"
-}

--- a/src/main/resources/assets/mpkmod/lang/pl_pl.lang
+++ b/src/main/resources/assets/mpkmod/lang/pl_pl.lang
@@ -1,2 +1,4 @@
 mpkmod.key.main_gui.desc=Otwórz menu Moda MPK
 mpkmod.key.lb_gui.desc=Otwórz menu bloku lądowania
+mpkmod.main_gui.title=Menu Moda MPK
+mpkmod.lb_gui.title=Menu bloku lądowania


### PR DESCRIPTION
Fix a crash in ClassUtil.getClasses()

Added type logging for option registry
Extracted OptionListItem into its own abstract class
Fixed "Reset All" button
Added option support for String, Integer and a fallback option that just displays the value

Update language files

Known issue: changing the integer value to an illegal value (e.g. 2.45) crashes the game