### PR TITLE
Use MC sprint input instead of key input + Fix timingEntries splitting + Add more timings

### DIFF
--- a/src/main/java/io/github/kurrycat/mpkmod/compatability/MC1_8/EventListener.java
+++ b/src/main/java/io/github/kurrycat/mpkmod/compatability/MC1_8/EventListener.java
@@ -58,6 +58,7 @@ public class EventListener {
                     .setRotation(mcPlayer.rotationYaw, mcPlayer.rotationPitch)
                     .setOnGround(mcPlayer.onGround)
                     .constructKeyInput()
+                    .setSprinting(mcPlayer.isSprinting())
                     .buildAndSave();
         }
         if (e.phase == TickEvent.Phase.START) {

--- a/src/main/java/io/github/kurrycat/mpkmod/compatability/MCClasses/Player.java
+++ b/src/main/java/io/github/kurrycat/mpkmod/compatability/MCClasses/Player.java
@@ -40,6 +40,7 @@ public class Player {
     private Vector3D lastHit = new Vector3D(0, 0, 0);
     private Vector3D lastJump = new Vector3D(0, 0, 0);
     private String lastTiming = "None";
+    private boolean sprinting = false;
 
     public static void savePlayerState(Player player) {
         tickHistory.add(player);
@@ -259,6 +260,15 @@ public class Player {
         return lastLanding;
     }
 
+    public boolean isSprinting() {
+        return sprinting;
+    }
+
+    public Player setSprinting(boolean sprinting) {
+        this.sprinting = sprinting;
+        return this;
+    }
+
     public Player buildAndSave() {
         Player.savePlayerState(this);
         Player prev = getPrevious();
@@ -283,7 +293,7 @@ public class Player {
                     keyInput.left,
                     keyInput.back,
                     keyInput.right,
-                    keyInput.sprint,
+                    sprinting,
                     keyInput.sneak,
                     jumpTick,
                     onGround

--- a/src/main/java/io/github/kurrycat/mpkmod/ticks/TimingEntry.java
+++ b/src/main/java/io/github/kurrycat/mpkmod/ticks/TimingEntry.java
@@ -25,7 +25,7 @@ public class TimingEntry {
     @JsonCreator
     public TimingEntry(String timingEntry) {
         this.timingEntry = timingEntry;
-        String[] split = timingEntry.split(":");
+        String[] split = timingEntry.split(":", -1);
         if (split.length == 1) {
             number = 1;
             varName = null;

--- a/src/main/resources/assets/mpkmod/strats/strats.json
+++ b/src/main/resources/assets/mpkmod/strats/strats.json
@@ -1,35 +1,115 @@
 {
   "fmm": {
     "format": {
-      "a+b==10": "3bc ",
-      "a==0": "Max ",
+      "a==1": "Max ",
       "default": "FMM",
-      "a!=0": " {a}t"
+      "a!=1": " {a}t"
     },
     "timingEntries": [
-      "WJ",
+      "a{1,1}:WJ",
       "a:W!G",
-      "b:WP!G",
-      "b{1,1}:WPG",
-      "WPJ"
+      "WP!G"
     ]
   },
   "c4.5": {
     "format": {
-      "a+b==10": "3bc ",
-      "a==0": "Max ",
+      "a==1": "Max ",
       "default": "c4.5",
-      "a!=0&&a!=3": " {a}t",
+      "a!=1&&a!=4": " {a}t",
       "r!=1": " Run {r}t"
     },
     "timingEntries": [
-      "WJ",
+      "a{1,1}:WJ",
       "a:W!G",
       "b:WP!G",
-      "b{1,1}:WPG",
+      "WPG",
       "r{1,}:WPG",
       "WPJ"
     ]
+  },
+  "pessi": {
+    "format": {
+      "a==1": "Max ",
+      "default": "Pessi",
+      "a!=1": " -{a}t"
+    },
+    "timingEntries": [
+      "a{1,1}:J",
+      "a:!G",
+      "WP!G"
+    ]
+  },
+  "a7hh": {
+    "format": {
+      "default": "A7HH"
+    },
+    "timingEntries": [
+      "a{1,1}:J",
+      "a:!G",
+      "WPG"
+    ]
+  },
+  "panefmm": {
+    "format": {
+      "a==1": "Max ",
+      "default": "Pane FMM",
+      "a!=1&&a!=4": " {a}t",
+      "r!=1": " Run {r}t"
+    },
+    "timingEntries": [
+      "a{1,1}:J",
+      "a:",
+      "b:WP!G",
+      "WPG",
+      "r{1,6}:WPG",
+      "WPJ"
+    ]
+  },
+  "jam": {
+    "format": {
+      "default": "Jam"
+    },
+    "timingEntries": [
+      "WPJ"
+    ]
+  },
+  "hh": {
+    "format": {
+      "default": "HH",
+      "x!=1": " {x}t"
+    },
+    "timingEntries": [
+      "x{1,}:WP",
+      "WPJ"
+    ]
+  },
+  "3bcbwmm": {
+    "format": {
+      "default": "3bc BWMM",
+      "w!=1": " Walk {w}t"
+    },
+    "timingEntries": [
+      "SJ",
+      "a:S!G",
+      "SG",
+      "w{1,}:SG",
+      "WPJ"
+    ]
+  },
+  "rexbwmm": {
+    "format": {
+      "default": "Rex BWMM",
+      "w!=1": " Walk {w}t",
+      "s!=1": " Strafe {s}t"
+    },
+    "timingEntries": [
+      "SJ",
+      "a:S!G",
+      "SG",
+      "w{1,}:SG",
+      "s{1,1}:WAPJ",
+      "s:WAP!G",
+      "WP!G"
+    ]
   }
 }
-


### PR DESCRIPTION
Changed keyInput.sprint to EntityPlayerSP.isSprinting() in Player/EventListener
Fixed constructor of TimingEntry trimming blank string at the end
Fixed FMM and c4.5 in strats.json
Added Pessi, A7HH, Pane FMM, Jam, HH, 3bc BWMM and Rex BWMM into strats.json

I hope I'm doing the pull request correctly xD