### PR TITLE
Fix DiscordRPC crashing on some linux distributions

### DIFF
--- a/common/src/main/java/io/github/kurrycat/mpkmod/discord/DiscordRPC.java
+++ b/common/src/main/java/io/github/kurrycat/mpkmod/discord/DiscordRPC.java
@@ -88,7 +88,7 @@ public class DiscordRPC {
     private static void createCore() {
         try (CreateParams params = new CreateParams()) {
             params.setClientID(CLIENT_ID);
-            params.setFlags(CreateParams.getDefaultFlags());
+            params.setFlags(CreateParams.Flags.NO_REQUIRE_DISCORD);
 
             try {
                 core = new Core(params);


### PR DESCRIPTION
Using `getDefaultFlags` causes the game to immediately crash when creating the Discord core.

It seems that this happens due to either not having Discord installed or installing it through something like Flathub.