### PR TITLE
Change landing mode switch behaviour

### DIFF
--- a/common/src/main/java/io/github/kurrycat/mpkmod/gui/screens/LandingBlockGuiScreen.java
+++ b/common/src/main/java/io/github/kurrycat/mpkmod/gui/screens/LandingBlockGuiScreen.java
@@ -180,21 +180,25 @@ public class LandingBlockGuiScreen extends ComponentScreen {
             deleteButton.pressedTextColor = Color.RED;
 
             landingModeButton = new Button("", Vector2D.OFFSCREEN, Vector2D.ZERO, mouseButton -> {
-                if (mouseButton == Mouse.Button.LEFT) {
-                    landingBlock.landingMode = landingBlock.landingMode.getNext();
-                } else if (Mouse.Button.RIGHT.equals(mouseButton)) {
-                    switch (landingBlock.landingMode) {
-                        case Z_NEO:
-                            landingBlock.boundingBox.setMinZ(landingBlock.boundingBox.getMin().getZ() + 0.6D);
-                            landingBlock.boundingBox.setMaxZ(landingBlock.boundingBox.getMax().getZ() - 0.6D);
-                            break;
-                        case ENTER:
-                            landingBlock.boundingBox.setMaxX((int) landingBlock.boundingBox.getMin().getX() + 0.7D);
-                            landingBlock.boundingBox.setMaxZ((int) landingBlock.boundingBox.getMin().getZ() + 0.7D);
-                            landingBlock.boundingBox.setMinX((int) landingBlock.boundingBox.getMin().getX() + 0.3D);
-                            landingBlock.boundingBox.setMinZ((int) landingBlock.boundingBox.getMin().getZ() + 0.3D);
-                            break;
-                    }
+                landingBlock.landingMode = landingBlock.landingMode.getNext();
+
+                switch (landingBlock.landingMode) {
+                    case Z_NEO:
+                        landingBlock.boundingBox.setMinZ(landingBlock.boundingBox.getMin().getZ() + 0.6D);
+                        landingBlock.boundingBox.setMaxZ(landingBlock.boundingBox.getMax().getZ() - 0.6D);
+                        break;
+                    case ENTER:
+                        landingBlock.boundingBox.setMaxX((int) landingBlock.boundingBox.getMin().getX() + 0.7D);
+                        landingBlock.boundingBox.setMaxZ((int) landingBlock.boundingBox.getMin().getZ() + 0.7D);
+                        landingBlock.boundingBox.setMinX((int) landingBlock.boundingBox.getMin().getX() + 0.3D);
+                        landingBlock.boundingBox.setMinZ((int) landingBlock.boundingBox.getMin().getZ() + 0.3D);
+                        break;
+                    case LAND:
+                        landingBlock.boundingBox.setMinX(landingBlock.boundingBox.getMin().getX() - 0.3D);
+                        landingBlock.boundingBox.setMaxX(landingBlock.boundingBox.getMax().getX() + 0.3D);
+                        landingBlock.boundingBox.setMinZ(landingBlock.boundingBox.getMin().getZ() - 0.3D);
+                        landingBlock.boundingBox.setMaxZ(landingBlock.boundingBox.getMax().getZ() + 0.3D);
+                        break;
                 }
             });
         }


### PR DESCRIPTION
Previously, when switching landing modes in the UI, you'd have to select the mode you want, and then right click with it to apply it.

With this change, I believe it should be much more intuitive, simply switch landing mode and it immediately applies it.

Also added a way to switch from ENTER to LAND, which was not previously there.